### PR TITLE
Add Telegram connect edge function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -294,6 +294,10 @@ inspector_port = 8083
 # The Deno major version to use.
 deno_version = 1
 
+# Environment variables available to all Edge Functions
+[edge_runtime.env]
+TELEGRAM_BOT_TOKEN = "env(TELEGRAM_BOT_TOKEN)"
+
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 

--- a/supabase/functions/telegram-connect/index.ts
+++ b/supabase/functions/telegram-connect/index.ts
@@ -1,0 +1,76 @@
+import { serve } from 'https://deno.land/std@0.203.0/http/server.ts';
+
+const telegramBotToken = Deno.env.get('TELEGRAM_BOT_TOKEN');
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, PUT, DELETE',
+};
+
+console.log('🚀 Telegram connect function started');
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders, status: 200 });
+  }
+
+  try {
+    const { user_id, username } = await req.json();
+
+    if (!user_id || !username) {
+      return new Response(
+        JSON.stringify({ success: false, error: "Missing 'user_id' or 'username'" }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!telegramBotToken) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Telegram bot token not configured' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const cleanUsername = username.startsWith('@') ? username.slice(1) : username;
+
+    const res = await fetch(`https://api.telegram.org/bot${telegramBotToken}/getUpdates`);
+    if (!res.ok) {
+      const errText = await res.text();
+      console.error('Telegram API error:', errText);
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to contact Telegram API' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await res.json();
+    const updates = Array.isArray(data.result) ? data.result : [];
+
+    let chatId: string | null = null;
+    for (const update of updates) {
+      const from = update?.message?.from;
+      if (from && from.username && from.username.toLowerCase() === cleanUsername.toLowerCase()) {
+        chatId = update.message.chat.id.toString();
+      }
+    }
+
+    if (!chatId) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Telegram user not verified. Message the bot with /start.' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, chat_id: chatId }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    console.error('Unexpected error:', err);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- implement `telegram-connect` edge function
- expose `TELEGRAM_BOT_TOKEN` to edge runtime in Supabase config

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e6f235c6483338e448093047fb19e