### PR TITLE
Add Vitest tests for Telegram integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.38.0",
@@ -33,6 +34,7 @@
     "eslint-plugin-react-refresh": "^0.4.4",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.5",
-    "vite": "^4.5.0"
+    "vite": "^4.5.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/tests/supabase.test.js
+++ b/tests/supabase.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => mockSupabase)
+}));
+
+let mockSupabase;
+let db;
+
+function setupSupabaseMocks() {
+  const invoke = vi.fn();
+  mockSupabase = {
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() => Promise.resolve({ data: {}, error: null }))
+          }))
+        }))
+      }))
+    })),
+    functions: { invoke }
+  };
+  return { invoke };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.VITE_SUPABASE_URL = 'http://localhost';
+  process.env.VITE_SUPABASE_ANON_KEY = 'anon';
+  setupSupabaseMocks();
+  ({ db } = await import('../src/lib/supabase.js'));
+});
+
+describe('sendTelegramNotification', () => {
+  it('sends notification to specific user', async () => {
+    const chatId = '111';
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { ok: true }, error: null });
+    db.getUserNotificationSettings = vi.fn().mockResolvedValue({ telegram_is_connected: true, telegram_notifications: true, telegram_chat_id: chatId });
+
+    const result = await db.sendTelegramNotification('ticket_created', 1, 'msg', 'user1');
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('send-telegram-notification', { body: { type: 'ticket_created', ticket_id: 1, message: 'msg', chat_ids: [chatId] } });
+    expect(result.success).toBe(true);
+    expect(result.recipients).toBe(1);
+  });
+
+  it('returns early when no recipients', async () => {
+    db.getUsersWithNotificationEnabled = vi.fn().mockResolvedValue([]);
+
+    const result = await db.sendTelegramNotification('ticket_created', 1, 'msg');
+
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, recipients: 0 });
+  });
+});
+
+describe('connectTelegram', () => {
+  it('invokes edge function and updates settings', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { success: true, chat_id: '123' }, error: null });
+
+    const res = await db.connectTelegram('u1', 'john');
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('telegram-connect', { body: { user_id: 'u1', username: '@john' } });
+    expect(mockSupabase.from).toHaveBeenCalledWith('user_settings');
+    expect(res.chat_id).toBe('123');
+    expect(res.username).toBe('@john');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    environment: 'node'
+  }
+};


### PR DESCRIPTION
## Summary
- configure Vitest and add test script
- add tests covering `sendTelegramNotification` and `connectTelegram`
- minimal Vitest config

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e763804a883339f43322525f1e841